### PR TITLE
Update README to suggest the appropriate groups in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Gem:
 Add `factory_girl_rails` to your Gemfile:
 
 ```ruby
-gem 'factory_girl_rails'
+group :development, :test do
+  gem 'factory_girl_rails'
+end
 ```
 
 Generators for factories will automatically substitute fixture (and maybe any other


### PR DESCRIPTION
This change makes it easier to understand which group `factory_girl_rails` belongs to in the `Gemfile`. By explicitly mentioning `:development` and `:test` we ensure that beginners won't add the gem into the global `Gemfile` namespace and therefore won't load this in production for no reason.

By the looks of it `factory_girl_rails` is in fact useful in `:development` as well to register itself for fixture replacements.